### PR TITLE
fix issue with missed QGIS widgets

### DIFF
--- a/src/milstd2525/ui/milstd2525rendererwidgetbase.ui
+++ b/src/milstd2525/ui/milstd2525rendererwidgetbase.ui
@@ -57,12 +57,12 @@
   <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
-   <header>qgsdoublespinbox.h</header>
+   <header>qgis.gui</header>
   </customwidget>
   <customwidget>
    <class>QgsFieldComboBox</class>
    <extends>QComboBox</extends>
-   <header>qgsfieldcombobox.h</header>
+   <header>qgis.gui</header>
   </customwidget>
  </customwidgets>
  <resources/>


### PR DESCRIPTION
This fixes import errors when QGIS custom widgets used under Windows